### PR TITLE
Create mini VPC for htan-dev

### DIFF
--- a/config/dev/htan-vpc.yaml
+++ b/config/dev/htan-vpc.yaml
@@ -1,0 +1,12 @@
+template_path: remote/vpc-mini.yaml
+stack_name: htan-vpc
+stack_tags:
+  Department: "CompOnc"
+  Project: "htan"
+  OwnerEmail: "bruno.grande@sagebase.org"
+parameters:
+  VpcName: htan-vpc
+  VpcSubnetPrefix: "10.255.31"
+hooks:
+  before_launch:
+    - !cmd "wget {{stack_group_config.aws_infra_templates_root_url}}/v0.2.13/templates/VPC/vpc-mini.yaml -N -P templates/remote"


### PR DESCRIPTION
This mini VPC will host the pre-production DSA server. I've already added the CIDR to the [Sage VPN table](https://sagebionetworks.jira.com/wiki/spaces/IT/pages/352976898/Sage+VPN). 

Could this be reviewed by @zaro0508 and @ahayden? I've invited you as admins on the repo so you have control in case something catastrophic happens. 