### PR TITLE
Use `-O` option for storing `wget` output to avoid caching

### DIFF
--- a/config/dev/dsa-prototype-ec2.yaml
+++ b/config/dev/dsa-prototype-ec2.yaml
@@ -16,4 +16,4 @@ stack_tags:
 
 hooks:
   before_launch:
-    - !cmd "wget {{stack_group_config.aws_infra_templates_root_url}}/v0.2.15/templates/EC2/basic-ec2.j2 -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_templates_root_url}}/v0.2.15/templates/EC2/basic-ec2.j2 -O templates/remote/basic-ec2.j2"

--- a/config/dev/htan-vpc.yaml
+++ b/config/dev/htan-vpc.yaml
@@ -9,4 +9,4 @@ parameters:
   VpcSubnetPrefix: "10.255.31"
 hooks:
   before_launch:
-    - !cmd "wget {{stack_group_config.aws_infra_templates_root_url}}/v0.2.13/templates/VPC/vpc-mini.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_templates_root_url}}/v0.2.13/templates/VPC/vpc-mini.yaml -O templates/remote/vpc-mini.yaml"


### PR DESCRIPTION
Prompted by Sage-Bionetworks/scicomp-provisioner#487. 