### PR TITLE
[IT-1331] replace sceptre hooks with template handler

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -28,9 +28,9 @@ jobs:
           role-to-assume: arn:aws:iam::888810830951:role/htan-dev-ci-service-account-ServiceRole-1I0ERPZD8ZKDS
           role-duration-seconds: 1200
       - name: Create directory for remote sceptre templates
-        run:  mkdir -p templates/remote/
+        run: mkdir -p templates/remote/
       - name: Deploy 'dev' configuration
-        uses: Sceptre/github-ci-action@v2.1.0
+        uses: Sceptre/github-ci-action@v2.2.0
         with:
-          sceptre_version: 2.5.0
+          sceptre_version: 2.7.1
           sceptre_subcommand: launch --yes dev

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Ignore anything downloaded by sceptre hooks during testing
 /templates/remote/
+
+# jetbrains
+.idea/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,19 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.1.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.17.0
+    rev: v1.26.3
     hooks:
       - id: yamllint
   - repo: https://github.com/awslabs/cfn-python-lint
-    rev: v0.29.0
+    rev: v0.57.0
     hooks:
       - id: cfn-python-lint
         files: templates/.*\.(json|yml|yaml)$
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.6
+    rev: v1.1.11
     hooks:
       - id: remove-tabs

--- a/config/dev/dsa-prototype-ec2.yaml
+++ b/config/dev/dsa-prototype-ec2.yaml
@@ -1,6 +1,6 @@
 template:
-  type: http
-  url: {{stack_group_config.aws_infra_templates_root_url}}/v0.2.15/templates/EC2/basic-ec2.j2
+  type: "http"
+  url: "{{stack_group_config.aws_infra_templates_root_url}}/v0.2.15/templates/EC2/basic-ec2.j2"
 stack_name: "dsa-prototype-ec2"
 dependencies:
   - "dev/htan-vpc.yaml"

--- a/config/dev/dsa-prototype-ec2.yaml
+++ b/config/dev/dsa-prototype-ec2.yaml
@@ -1,4 +1,6 @@
-template_path: "remote/basic-ec2.j2"
+template:
+  type: http
+  url: {{stack_group_config.aws_infra_templates_root_url}}/v0.2.15/templates/EC2/basic-ec2.j2
 stack_name: "dsa-prototype-ec2"
 dependencies:
   - "dev/htan-vpc.yaml"
@@ -13,7 +15,3 @@ stack_tags:
   Department: "CompOnc"
   Project: "htan"
   OwnerEmail: "bruno.grande@sagebase.org"
-
-hooks:
-  before_launch:
-    - !cmd "wget {{stack_group_config.aws_infra_templates_root_url}}/v0.2.15/templates/EC2/basic-ec2.j2 -O templates/remote/basic-ec2.j2"

--- a/config/dev/dsa-prototype-ec2.yaml
+++ b/config/dev/dsa-prototype-ec2.yaml
@@ -15,3 +15,4 @@ stack_tags:
   Department: "CompOnc"
   Project: "htan"
   OwnerEmail: "bruno.grande@sagebase.org"
+  CostCenter: "HTAN-DFCI / 120100"

--- a/config/dev/htan-vpc.yaml
+++ b/config/dev/htan-vpc.yaml
@@ -1,4 +1,6 @@
-template_path: remote/vpc-mini.yaml
+template:
+  type: http
+  url: {{stack_group_config.aws_infra_templates_root_url}}/v0.2.13/templates/VPC/vpc-mini.yaml
 stack_name: htan-vpc
 stack_tags:
   Department: "CompOnc"
@@ -7,6 +9,3 @@ stack_tags:
 parameters:
   VpcName: htan-vpc
   VpcSubnetPrefix: "10.255.31"
-hooks:
-  before_launch:
-    - !cmd "wget {{stack_group_config.aws_infra_templates_root_url}}/v0.2.13/templates/VPC/vpc-mini.yaml -O templates/remote/vpc-mini.yaml"

--- a/config/dev/htan-vpc.yaml
+++ b/config/dev/htan-vpc.yaml
@@ -1,6 +1,6 @@
 template:
-  type: http
-  url: {{stack_group_config.aws_infra_templates_root_url}}/v0.2.13/templates/VPC/vpc-mini.yaml
+  type: "http"
+  url: "{{stack_group_config.aws_infra_templates_root_url}}/v0.2.13/templates/VPC/vpc-mini.yaml"
 stack_name: htan-vpc
 stack_tags:
   Department: "CompOnc"

--- a/config/dev/htan-vpc.yaml
+++ b/config/dev/htan-vpc.yaml
@@ -6,6 +6,7 @@ stack_tags:
   Department: "CompOnc"
   Project: "htan"
   OwnerEmail: "bruno.grande@sagebase.org"
+  CostCenter: "HTAN-DFCI / 120100"
 parameters:
   VpcName: htan-vpc
   VpcSubnetPrefix: "10.255.31"


### PR DESCRIPTION
Sceptre has template handlers[1] now so we can abandon the use of
hooks in favor of the http template handler to get templates
from our shared template repository. This updates some of the ones
we missed from previous updates

[1] https://sceptre.cloudreach.com/dev/docs/template_handlers.html#template-handlers