### PR TITLE
[IT-3834] Remove owner tag from htan-vpc stack

### DIFF
--- a/config/dev/htan-vpc.yaml
+++ b/config/dev/htan-vpc.yaml
@@ -2,11 +2,6 @@ template:
   type: "http"
   url: "{{stack_group_config.aws_infra_templates_root_url}}/v0.2.13/templates/VPC/vpc-mini.yaml"
 stack_name: htan-vpc
-stack_tags:
-  Department: "CompOnc"
-  Project: "htan"
-  OwnerEmail: "bruno.grande@sagebase.org"
-  CostCenter: "HTAN-DFCI / 120100"
 parameters:
   VpcName: htan-vpc
   VpcSubnetPrefix: "10.255.31"


### PR DESCRIPTION
Remove the owner email tag from the `htan-vpc` cloudformation stack. Its currently set to a former employee, change to falling back to the account tags.