### PR TITLE
Decommission `htan-vpc`

### DIFF
--- a/config/dev/htan-vpc.yaml
+++ b/config/dev/htan-vpc.yaml
@@ -1,7 +1,0 @@
-template:
-  type: "http"
-  url: "{{stack_group_config.aws_infra_templates_root_url}}/v0.2.13/templates/VPC/vpc-mini.yaml"
-stack_name: htan-vpc
-parameters:
-  VpcName: htan-vpc
-  VpcSubnetPrefix: "10.255.31"


### PR DESCRIPTION
As far as I can tell from CloudWatch and the Cost Management explorer this VPC has not been used since at least mid 2022 and relates to an old deployment of an internal application which is has been long defunct.

We can therefore decommission this infra as it has some ongoing costs associated with it (seems to be about $18/month from the NAT Gateway.